### PR TITLE
select_end_match_eof was introduced in 3.9

### DIFF
--- a/lib/files.cf
+++ b/lib/files.cf
@@ -1210,7 +1210,7 @@ body select_region INI_section(x)
       select_start => "\[$(x)\]\s*";
       select_end => "\[.*\]\s*";
 
-@if minimum_version(3.10)
+@if minimum_version(3.9)
       select_end_match_eof => "true";
 @endif
 }


### PR DESCRIPTION
In the INI_section select_region body, the minimum version for use of the select_end_match_eof was specified as 3.10, when it was actually introduced in 3.9 per the docs: https://docs.cfengine.com/docs/3.9/reference-promise-types-edit_line.html